### PR TITLE
refactor: 共通ゲームロジックのカスタムフック抽出

### DIFF
--- a/src/hooks/__tests__/useGameFeedback.test.tsx
+++ b/src/hooks/__tests__/useGameFeedback.test.tsx
@@ -1,0 +1,242 @@
+import { renderHook, act } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { useGameFeedback } from '../useGameFeedback';
+import { AudioProvider } from '@/contexts/AudioContext';
+
+// AudioProviderでラップするwrapper
+const wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <AudioProvider>{children}</AudioProvider>
+);
+
+describe('useGameFeedback', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('初期状態', () => {
+    it('デフォルトの初期状態が正しく設定される', () => {
+      const { result } = renderHook(() => useGameFeedback(), { wrapper });
+
+      expect(result.current.feedback).toBe('neutral');
+      expect(result.current.isCorrect).toBeNull();
+      expect(result.current.isShowingFeedback).toBe(false);
+    });
+  });
+
+  describe('showCorrect', () => {
+    it('正解フィードバックを表示する', async () => {
+      const { result } = renderHook(() => useGameFeedback(), { wrapper });
+
+      await act(async () => {
+        result.current.showCorrect();
+      });
+
+      expect(result.current.feedback).toBe('correct');
+      expect(result.current.isCorrect).toBe(true);
+      expect(result.current.isShowingFeedback).toBe(true);
+    });
+
+    it('指定時間後にフィードバックが終了する', async () => {
+      const { result } = renderHook(() => useGameFeedback({ feedbackDuration: 1000 }), { wrapper });
+
+      await act(async () => {
+        result.current.showCorrect();
+      });
+
+      expect(result.current.isShowingFeedback).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.isShowingFeedback).toBe(false);
+      expect(result.current.isCorrect).toBe(true); // isCorrectは維持される
+    });
+
+    it('効果音を再生する', async () => {
+      const mockPlay = jest.fn().mockResolvedValue(undefined);
+      (global.Audio as jest.Mock).mockImplementation(() => ({
+        play: mockPlay,
+        volume: 1,
+        currentTime: 0,
+        crossOrigin: '',
+        preload: '',
+        src: '',
+      }));
+
+      const { result } = renderHook(() => useGameFeedback(), { wrapper });
+
+      // オーディオを初期化
+      await act(async () => {
+        // AudioContextのinitializeAudioを呼ぶ代わりに、直接テスト
+      });
+
+      await act(async () => {
+        result.current.showCorrect();
+      });
+
+      // 効果音が再生されることを確認（AudioProviderの内部実装による）
+      expect(result.current.feedback).toBe('correct');
+    });
+  });
+
+  describe('showIncorrect', () => {
+    it('不正解フィードバックを表示する', async () => {
+      const { result } = renderHook(() => useGameFeedback(), { wrapper });
+
+      await act(async () => {
+        result.current.showIncorrect();
+      });
+
+      expect(result.current.feedback).toBe('incorrect');
+      expect(result.current.isCorrect).toBe(false);
+      expect(result.current.isShowingFeedback).toBe(true);
+    });
+
+    it('指定時間後にフィードバックが終了する', async () => {
+      const { result } = renderHook(() => useGameFeedback({ feedbackDuration: 500 }), { wrapper });
+
+      await act(async () => {
+        result.current.showIncorrect();
+      });
+
+      expect(result.current.isShowingFeedback).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(result.current.isShowingFeedback).toBe(false);
+    });
+  });
+
+  describe('resetFeedback', () => {
+    it('フィードバックをリセットする', async () => {
+      const { result } = renderHook(() => useGameFeedback(), { wrapper });
+
+      await act(async () => {
+        result.current.showCorrect();
+      });
+
+      expect(result.current.isCorrect).toBe(true);
+
+      act(() => {
+        result.current.resetFeedback();
+      });
+
+      expect(result.current.feedback).toBe('neutral');
+      expect(result.current.isCorrect).toBeNull();
+      expect(result.current.isShowingFeedback).toBe(false);
+    });
+
+    it('タイマーをクリアする', async () => {
+      const { result } = renderHook(() => useGameFeedback({ feedbackDuration: 5000 }), { wrapper });
+
+      await act(async () => {
+        result.current.showCorrect();
+      });
+
+      act(() => {
+        result.current.resetFeedback();
+      });
+
+      // タイマーが進んでもisShowingFeedbackはfalseのまま
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(result.current.isShowingFeedback).toBe(false);
+    });
+  });
+
+  describe('playClick', () => {
+    it('クリック音を再生できる', async () => {
+      const { result } = renderHook(() => useGameFeedback(), { wrapper });
+
+      // エラーなく実行できることを確認
+      await act(async () => {
+        await result.current.playClick();
+      });
+
+      // playClickの呼び出しが成功することを確認
+      expect(result.current.feedback).toBe('neutral');
+    });
+  });
+
+  describe('playFeedbackSound', () => {
+    it('カスタム効果音を再生できる', async () => {
+      const { result } = renderHook(() => useGameFeedback(), { wrapper });
+
+      await act(async () => {
+        await result.current.playFeedbackSound('complete');
+      });
+
+      // エラーなく実行できることを確認
+      expect(result.current.feedback).toBe('neutral');
+    });
+  });
+
+  describe('カスタムオプション', () => {
+    it('カスタム効果音を指定できる', async () => {
+      const { result } = renderHook(
+        () =>
+          useGameFeedback({
+            correctSound: 'complete',
+            incorrectSound: 'click',
+          }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        result.current.showCorrect();
+      });
+
+      expect(result.current.isCorrect).toBe(true);
+    });
+
+    it('soundEnabled: falseで効果音を無効化できる', async () => {
+      const mockPlay = jest.fn().mockResolvedValue(undefined);
+      (global.Audio as jest.Mock).mockImplementation(() => ({
+        play: mockPlay,
+        volume: 1,
+        currentTime: 0,
+        crossOrigin: '',
+        preload: '',
+        src: '',
+      }));
+
+      const { result } = renderHook(() => useGameFeedback({ soundEnabled: false }), { wrapper });
+
+      await act(async () => {
+        result.current.showCorrect();
+      });
+
+      // フィードバック状態は変わるが、効果音は再生されない
+      expect(result.current.isCorrect).toBe(true);
+    });
+  });
+
+  describe('連続呼び出し', () => {
+    it('フィードバック中に別のフィードバックを呼ぶと上書きされる', async () => {
+      const { result } = renderHook(() => useGameFeedback({ feedbackDuration: 2000 }), { wrapper });
+
+      await act(async () => {
+        result.current.showCorrect();
+      });
+
+      expect(result.current.isCorrect).toBe(true);
+
+      await act(async () => {
+        result.current.showIncorrect();
+      });
+
+      expect(result.current.isCorrect).toBe(false);
+      expect(result.current.feedback).toBe('incorrect');
+    });
+  });
+});

--- a/src/hooks/__tests__/useGameProgress.test.ts
+++ b/src/hooks/__tests__/useGameProgress.test.ts
@@ -1,0 +1,256 @@
+import { renderHook, act } from '@testing-library/react';
+import { useGameProgress } from '../useGameProgress';
+
+describe('useGameProgress', () => {
+  describe('初期状態', () => {
+    it('totalItems: 10の場合、初期状態が正しく設定される', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10 }));
+
+      expect(result.current.state.currentIndex).toBe(0);
+      expect(result.current.state.score).toBe(0);
+      expect(result.current.state.gameStarted).toBe(false);
+      expect(result.current.state.gameCompleted).toBe(false);
+      expect(result.current.progress).toBe(10); // (0 + 1) / 10 * 100 = 10%
+      expect(result.current.isFirst).toBe(true);
+      expect(result.current.isLast).toBe(false);
+      expect(result.current.totalItems).toBe(10);
+    });
+
+    it('initialIndexとinitialScoreを指定できる', () => {
+      const { result } = renderHook(() =>
+        useGameProgress({ totalItems: 10, initialIndex: 5, initialScore: 100 }),
+      );
+
+      expect(result.current.state.currentIndex).toBe(5);
+      expect(result.current.state.score).toBe(100);
+      expect(result.current.progress).toBe(60); // (5 + 1) / 10 * 100 = 60%
+    });
+
+    it('totalItems: 0の場合、progress: 0になる', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 0 }));
+
+      expect(result.current.progress).toBe(0);
+    });
+  });
+
+  describe('handleNext', () => {
+    it('次のアイテムに進む', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10 }));
+
+      act(() => {
+        result.current.handleNext();
+      });
+
+      expect(result.current.state.currentIndex).toBe(1);
+      expect(result.current.progress).toBe(20); // (1 + 1) / 10 * 100 = 20%
+      expect(result.current.isFirst).toBe(false);
+    });
+
+    it('最後のアイテムでhandleNextを呼ぶとgameCompletedになる', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 3 }));
+
+      // 0 -> 1
+      act(() => {
+        result.current.handleNext();
+      });
+      expect(result.current.state.gameCompleted).toBe(false);
+
+      // 1 -> 2 (last item)
+      act(() => {
+        result.current.handleNext();
+      });
+      expect(result.current.isLast).toBe(true);
+      expect(result.current.state.gameCompleted).toBe(false);
+
+      // 2 -> complete
+      act(() => {
+        result.current.handleNext();
+      });
+      expect(result.current.state.gameCompleted).toBe(true);
+      expect(result.current.state.currentIndex).toBe(2); // インデックスは変わらない
+    });
+  });
+
+  describe('handlePrevious', () => {
+    it('前のアイテムに戻る', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10, initialIndex: 5 }));
+
+      act(() => {
+        result.current.handlePrevious();
+      });
+
+      expect(result.current.state.currentIndex).toBe(4);
+    });
+
+    it('最初のアイテムでhandlePreviousを呼んでも0のまま', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10 }));
+
+      act(() => {
+        result.current.handlePrevious();
+      });
+
+      expect(result.current.state.currentIndex).toBe(0);
+      expect(result.current.isFirst).toBe(true);
+    });
+  });
+
+  describe('startGame', () => {
+    it('ゲームを開始する', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10 }));
+
+      expect(result.current.state.gameStarted).toBe(false);
+
+      act(() => {
+        result.current.startGame();
+      });
+
+      expect(result.current.state.gameStarted).toBe(true);
+    });
+  });
+
+  describe('addScore', () => {
+    it('スコアを加算する', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10 }));
+
+      act(() => {
+        result.current.addScore(10);
+      });
+
+      expect(result.current.state.score).toBe(10);
+
+      act(() => {
+        result.current.addScore(25);
+      });
+
+      expect(result.current.state.score).toBe(35);
+    });
+
+    it('負の値も加算できる', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10, initialScore: 50 }));
+
+      act(() => {
+        result.current.addScore(-10);
+      });
+
+      expect(result.current.state.score).toBe(40);
+    });
+  });
+
+  describe('goToIndex', () => {
+    it('特定のインデックスに移動する', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10 }));
+
+      act(() => {
+        result.current.goToIndex(5);
+      });
+
+      expect(result.current.state.currentIndex).toBe(5);
+      expect(result.current.progress).toBe(60);
+    });
+
+    it('範囲外のインデックスは無視される', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10 }));
+
+      act(() => {
+        result.current.goToIndex(15);
+      });
+      expect(result.current.state.currentIndex).toBe(0);
+
+      act(() => {
+        result.current.goToIndex(-1);
+      });
+      expect(result.current.state.currentIndex).toBe(0);
+    });
+
+    it('goToIndexでgameCompletedがリセットされる', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 3 }));
+
+      // 完了状態にする
+      act(() => {
+        result.current.handleNext();
+        result.current.handleNext();
+        result.current.handleNext();
+      });
+      expect(result.current.state.gameCompleted).toBe(true);
+
+      // 別のインデックスに移動
+      act(() => {
+        result.current.goToIndex(0);
+      });
+      expect(result.current.state.gameCompleted).toBe(false);
+    });
+  });
+
+  describe('resetGame', () => {
+    it('ゲームをリセットする', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 10 }));
+
+      // 状態を変更
+      act(() => {
+        result.current.startGame();
+        result.current.handleNext();
+        result.current.handleNext();
+        result.current.addScore(50);
+      });
+
+      expect(result.current.state.currentIndex).toBe(2);
+      expect(result.current.state.score).toBe(50);
+      expect(result.current.state.gameStarted).toBe(true);
+
+      // リセット
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(result.current.state.currentIndex).toBe(0);
+      expect(result.current.state.score).toBe(0);
+      expect(result.current.state.gameStarted).toBe(false);
+      expect(result.current.state.gameCompleted).toBe(false);
+    });
+
+    it('initialIndexとinitialScoreにリセットされる', () => {
+      const { result } = renderHook(() =>
+        useGameProgress({ totalItems: 10, initialIndex: 3, initialScore: 100 }),
+      );
+
+      act(() => {
+        result.current.handleNext();
+        result.current.addScore(50);
+      });
+
+      expect(result.current.state.currentIndex).toBe(4);
+      expect(result.current.state.score).toBe(150);
+
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(result.current.state.currentIndex).toBe(3);
+      expect(result.current.state.score).toBe(100);
+    });
+  });
+
+  describe('isFirst / isLast', () => {
+    it('最初と最後のアイテムを正しく判定する', () => {
+      const { result } = renderHook(() => useGameProgress({ totalItems: 3 }));
+
+      // 最初のアイテム
+      expect(result.current.isFirst).toBe(true);
+      expect(result.current.isLast).toBe(false);
+
+      // 中間のアイテム
+      act(() => {
+        result.current.handleNext();
+      });
+      expect(result.current.isFirst).toBe(false);
+      expect(result.current.isLast).toBe(false);
+
+      // 最後のアイテム
+      act(() => {
+        result.current.handleNext();
+      });
+      expect(result.current.isFirst).toBe(false);
+      expect(result.current.isLast).toBe(true);
+    });
+  });
+});

--- a/src/hooks/__tests__/useGameTimer.test.ts
+++ b/src/hooks/__tests__/useGameTimer.test.ts
@@ -1,0 +1,302 @@
+import { renderHook, act } from '@testing-library/react';
+import { useGameTimer } from '../useGameTimer';
+
+describe('useGameTimer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('初期状態', () => {
+    it('デフォルトの初期状態が正しく設定される', () => {
+      const { result } = renderHook(() => useGameTimer());
+
+      expect(result.current.elapsedTime).toBe(0);
+      expect(result.current.remainingTime).toBe(0);
+      expect(result.current.isRunning).toBe(false);
+      expect(result.current.isTimedOut).toBe(false);
+    });
+
+    it('autoStart: trueの場合、開始状態になる', () => {
+      const { result } = renderHook(() => useGameTimer({ autoStart: true }));
+
+      expect(result.current.isRunning).toBe(true);
+    });
+
+    it('countdownモードでtimeoutを設定すると、remainingTimeが設定される', () => {
+      const { result } = renderHook(() => useGameTimer({ timeout: 30000, mode: 'countdown' }));
+
+      expect(result.current.remainingTime).toBe(30000);
+    });
+  });
+
+  describe('start / stop', () => {
+    it('startでタイマーが開始される', () => {
+      const { result } = renderHook(() => useGameTimer());
+
+      expect(result.current.isRunning).toBe(false);
+
+      act(() => {
+        result.current.start();
+      });
+
+      expect(result.current.isRunning).toBe(true);
+    });
+
+    it('stopでタイマーが停止しリセットされる', () => {
+      const { result } = renderHook(() => useGameTimer({ autoStart: true }));
+
+      // 時間を進める
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(result.current.elapsedTime).toBeGreaterThan(0);
+
+      act(() => {
+        result.current.stop();
+      });
+
+      expect(result.current.isRunning).toBe(false);
+      expect(result.current.elapsedTime).toBe(0);
+      expect(result.current.isTimedOut).toBe(false);
+    });
+  });
+
+  describe('pause / resume', () => {
+    it('pauseでタイマーが一時停止する', () => {
+      const { result } = renderHook(() => useGameTimer({ autoStart: true }));
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      const elapsedBeforePause = result.current.elapsedTime;
+
+      act(() => {
+        result.current.pause();
+      });
+
+      expect(result.current.isRunning).toBe(false);
+
+      // 一時停止中は時間が進まない
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+
+      expect(result.current.elapsedTime).toBe(elapsedBeforePause);
+    });
+
+    it('resumeでタイマーが再開する', () => {
+      const { result } = renderHook(() => useGameTimer({ autoStart: true }));
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      act(() => {
+        result.current.pause();
+      });
+
+      const elapsedAtPause = result.current.elapsedTime;
+
+      act(() => {
+        result.current.resume();
+      });
+
+      expect(result.current.isRunning).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.elapsedTime).toBeGreaterThan(elapsedAtPause);
+    });
+  });
+
+  describe('reset', () => {
+    it('resetでタイマーがリセットされる', () => {
+      const { result } = renderHook(() => useGameTimer({ autoStart: true }));
+
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(result.current.elapsedTime).toBeGreaterThan(0);
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.elapsedTime).toBe(0);
+      expect(result.current.isTimedOut).toBe(false);
+    });
+  });
+
+  describe('カウントダウンモード', () => {
+    it('remainingTimeが正しく計算される', () => {
+      const { result } = renderHook(() =>
+        useGameTimer({ timeout: 10000, mode: 'countdown', autoStart: true, interval: 100 }),
+      );
+
+      expect(result.current.remainingTime).toBe(10000);
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      // remainingTimeは減少する
+      expect(result.current.remainingTime).toBeLessThan(10000);
+      expect(result.current.remainingTime).toBeGreaterThan(0);
+    });
+
+    it('タイムアウト時にonTimeoutが呼ばれる', () => {
+      const onTimeout = jest.fn();
+      const { result } = renderHook(() =>
+        useGameTimer({
+          timeout: 1000,
+          mode: 'countdown',
+          autoStart: true,
+          onTimeout,
+          interval: 100,
+        }),
+      );
+
+      expect(onTimeout).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(1200);
+      });
+
+      expect(result.current.isTimedOut).toBe(true);
+      expect(result.current.isRunning).toBe(false);
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    it('タイムアウト後はremainingTimeが0になる', () => {
+      const { result } = renderHook(() =>
+        useGameTimer({
+          timeout: 1000,
+          mode: 'countdown',
+          autoStart: true,
+          interval: 100,
+        }),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(result.current.remainingTime).toBe(0);
+    });
+  });
+
+  describe('カウントアップモード', () => {
+    it('elapsedTimeが増加する', () => {
+      const { result } = renderHook(() => useGameTimer({ mode: 'countup', autoStart: true }));
+
+      expect(result.current.elapsedTime).toBe(0);
+
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+
+      expect(result.current.elapsedTime).toBeGreaterThan(0);
+    });
+
+    it('countupモードではタイムアウトしない', () => {
+      const onTimeout = jest.fn();
+      const { result } = renderHook(() =>
+        useGameTimer({
+          mode: 'countup',
+          autoStart: true,
+          onTimeout,
+        }),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(100000);
+      });
+
+      expect(result.current.isTimedOut).toBe(false);
+      expect(onTimeout).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('カスタムinterval', () => {
+    it('指定したintervalで更新される', () => {
+      const { result } = renderHook(() => useGameTimer({ autoStart: true, interval: 500 }));
+
+      expect(result.current.elapsedTime).toBe(0);
+
+      // 500ms未満では更新されない
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+      expect(result.current.elapsedTime).toBe(0);
+
+      // 500ms以上で更新される
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(result.current.elapsedTime).toBeGreaterThan(0);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('タイムアウト後にstartしても開始しない', () => {
+      const { result } = renderHook(() =>
+        useGameTimer({
+          timeout: 1000,
+          mode: 'countdown',
+          autoStart: true,
+          interval: 100,
+        }),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1500);
+      });
+
+      expect(result.current.isTimedOut).toBe(true);
+
+      act(() => {
+        result.current.start();
+      });
+
+      expect(result.current.isRunning).toBe(false);
+    });
+
+    it('resetするとタイムアウト後もstartできる', () => {
+      const { result } = renderHook(() =>
+        useGameTimer({
+          timeout: 1000,
+          mode: 'countdown',
+          autoStart: true,
+          interval: 100,
+        }),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1500);
+      });
+
+      expect(result.current.isTimedOut).toBe(true);
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.isTimedOut).toBe(false);
+
+      act(() => {
+        result.current.start();
+      });
+
+      expect(result.current.isRunning).toBe(true);
+    });
+  });
+});

--- a/src/hooks/__tests__/useKanjiText.test.tsx
+++ b/src/hooks/__tests__/useKanjiText.test.tsx
@@ -1,0 +1,281 @@
+import { renderHook } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { useKanjiText, useKanjiTexts, type KanjiTextMap } from '../useKanjiText';
+import { LanguageProvider } from '@/contexts/LanguageContext';
+
+// LanguageProviderでラップするwrapper
+const wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <LanguageProvider>{children}</LanguageProvider>
+);
+
+describe('useKanjiText', () => {
+  // テスト用の漢字レベル別テキスト
+  const sampleKanjiTextMap: KanjiTextMap = {
+    1: 'ひらがなだけ',
+    2: '少し漢字',
+    3: '普通の漢字',
+    4: '難しい漢字',
+    5: '更に難しい漢字',
+    6: '最も難しい漢字',
+  };
+
+  describe('基本機能', () => {
+    it('デフォルトの漢字レベル（1）のテキストを返す', () => {
+      const { result } = renderHook(() => useKanjiText(sampleKanjiTextMap), { wrapper });
+
+      expect(result.current.text).toBe('ひらがなだけ');
+      expect(result.current.currentGrade).toBe(1);
+    });
+
+    it('undefinedのkanjiTextMapの場合、空文字を返す', () => {
+      const { result } = renderHook(() => useKanjiText(undefined), { wrapper });
+
+      expect(result.current.text).toBe('');
+    });
+
+    it('fallbackTextを指定できる', () => {
+      const { result } = renderHook(
+        () => useKanjiText(undefined, { fallbackText: 'フォールバック' }),
+        { wrapper },
+      );
+
+      expect(result.current.text).toBe('フォールバック');
+    });
+  });
+
+  describe('overrideGrade', () => {
+    it('overrideGradeで漢字レベルを上書きできる', () => {
+      const { result } = renderHook(() => useKanjiText(sampleKanjiTextMap, { overrideGrade: 3 }), {
+        wrapper,
+      });
+
+      expect(result.current.text).toBe('普通の漢字');
+      expect(result.current.currentGrade).toBe(3);
+    });
+
+    it('overrideGrade: 6で最も難しいテキストを返す', () => {
+      const { result } = renderHook(() => useKanjiText(sampleKanjiTextMap, { overrideGrade: 6 }), {
+        wrapper,
+      });
+
+      expect(result.current.text).toBe('最も難しい漢字');
+    });
+  });
+
+  describe('フォールバック', () => {
+    it('指定レベルにテキストがない場合、より低いレベルにフォールバックする', () => {
+      const partialMap: KanjiTextMap = {
+        1: 'レベル1',
+        2: '',
+        3: '',
+        4: 'レベル4',
+        5: '',
+        6: '',
+      };
+
+      const { result } = renderHook(() => useKanjiText(partialMap, { overrideGrade: 3 }), {
+        wrapper,
+      });
+
+      // レベル3がないので、レベル1にフォールバック
+      expect(result.current.text).toBe('レベル1');
+    });
+
+    it('すべてのレベルにテキストがない場合、fallbackTextを返す', () => {
+      const emptyMap: KanjiTextMap = {
+        1: '',
+        2: '',
+        3: '',
+        4: '',
+        5: '',
+        6: '',
+      };
+
+      const { result } = renderHook(() => useKanjiText(emptyMap, { fallbackText: 'デフォルト' }), {
+        wrapper,
+      });
+
+      expect(result.current.text).toBe('デフォルト');
+    });
+
+    it('空白のみのテキストもフォールバック対象になる', () => {
+      const whitespaceMap: KanjiTextMap = {
+        1: '有効なテキスト',
+        2: '   ', // 空白のみ
+        3: '',
+        4: '',
+        5: '',
+        6: '',
+      };
+
+      const { result } = renderHook(() => useKanjiText(whitespaceMap, { overrideGrade: 2 }), {
+        wrapper,
+      });
+
+      expect(result.current.text).toBe('有効なテキスト');
+    });
+  });
+
+  describe('getTextForGrade', () => {
+    it('特定のレベルのテキストを取得できる', () => {
+      const { result } = renderHook(() => useKanjiText(sampleKanjiTextMap), { wrapper });
+
+      expect(result.current.getTextForGrade(1)).toBe('ひらがなだけ');
+      expect(result.current.getTextForGrade(3)).toBe('普通の漢字');
+      expect(result.current.getTextForGrade(6)).toBe('最も難しい漢字');
+    });
+
+    it('getTextForGradeもフォールバックロジックを持つ', () => {
+      const partialMap: KanjiTextMap = {
+        1: 'レベル1',
+        2: '',
+        3: 'レベル3',
+        4: '',
+        5: '',
+        6: '',
+      };
+
+      const { result } = renderHook(() => useKanjiText(partialMap), { wrapper });
+
+      expect(result.current.getTextForGrade(2)).toBe('レベル1');
+      expect(result.current.getTextForGrade(5)).toBe('レベル3');
+    });
+  });
+});
+
+describe('useKanjiTexts', () => {
+  describe('基本機能', () => {
+    it('複数のテキストを一括で変換できる', () => {
+      const titleMap: KanjiTextMap = {
+        1: 'たいとる',
+        2: 'タイトル',
+        3: '題名',
+        4: '題名',
+        5: '題名',
+        6: '題名',
+      };
+
+      const descriptionMap: KanjiTextMap = {
+        1: 'せつめい',
+        2: '説明',
+        3: '説明',
+        4: '説明',
+        5: '説明',
+        6: '説明',
+      };
+
+      const { result } = renderHook(
+        () =>
+          useKanjiTexts({
+            title: titleMap,
+            description: descriptionMap,
+          }),
+        { wrapper },
+      );
+
+      // デフォルトレベル1
+      expect(result.current.title).toBe('たいとる');
+      expect(result.current.description).toBe('せつめい');
+    });
+
+    it('undefinedのマップはfallbackTextになる', () => {
+      const titleMap: KanjiTextMap = {
+        1: 'たいとる',
+        2: 'タイトル',
+        3: '題名',
+        4: '題名',
+        5: '題名',
+        6: '題名',
+      };
+
+      const { result } = renderHook(
+        () =>
+          useKanjiTexts(
+            {
+              title: titleMap,
+              missing: undefined,
+            },
+            { fallbackText: 'デフォルト' },
+          ),
+        { wrapper },
+      );
+
+      expect(result.current.title).toBe('たいとる');
+      expect(result.current.missing).toBe('デフォルト');
+    });
+  });
+
+  describe('overrideGrade', () => {
+    it('overrideGradeで全てのテキストのレベルを上書きできる', () => {
+      const titleMap: KanjiTextMap = {
+        1: 'たいとる',
+        2: 'タイトル',
+        3: '題名',
+        4: '題名',
+        5: '題名',
+        6: '題名',
+      };
+
+      const descriptionMap: KanjiTextMap = {
+        1: 'せつめい',
+        2: '説明',
+        3: '説明文',
+        4: '説明文',
+        5: '説明文',
+        6: '説明文',
+      };
+
+      const { result } = renderHook(
+        () =>
+          useKanjiTexts(
+            {
+              title: titleMap,
+              description: descriptionMap,
+            },
+            { overrideGrade: 3 },
+          ),
+        { wrapper },
+      );
+
+      expect(result.current.title).toBe('題名');
+      expect(result.current.description).toBe('説明文');
+    });
+  });
+
+  describe('フォールバック', () => {
+    it('各テキストに個別にフォールバックが適用される', () => {
+      const titleMap: KanjiTextMap = {
+        1: 'たいとる',
+        2: '',
+        3: '題名',
+        4: '',
+        5: '',
+        6: '',
+      };
+
+      const descriptionMap: KanjiTextMap = {
+        1: '',
+        2: '',
+        3: '',
+        4: '',
+        5: '',
+        6: '',
+      };
+
+      const { result } = renderHook(
+        () =>
+          useKanjiTexts(
+            {
+              title: titleMap,
+              description: descriptionMap,
+            },
+            { overrideGrade: 2, fallbackText: 'なし' },
+          ),
+        { wrapper },
+      );
+
+      expect(result.current.title).toBe('たいとる'); // レベル1にフォールバック
+      expect(result.current.description).toBe('なし'); // fallbackText
+    });
+  });
+});

--- a/src/hooks/__tests__/useShuffle.test.ts
+++ b/src/hooks/__tests__/useShuffle.test.ts
@@ -1,0 +1,172 @@
+import { renderHook, act } from '@testing-library/react';
+import { useShuffle, getDailyShuffleSeed, getRandomSeed } from '../useShuffle';
+
+describe('useShuffle', () => {
+  const testItems = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  describe('基本機能', () => {
+    it('配列をシャッフルして返す', () => {
+      const { result } = renderHook(() => useShuffle(testItems, { seedType: 'random' }));
+
+      expect(result.current.shuffledItems).toHaveLength(testItems.length);
+      // シャッフルされた配列は元の配列と同じ要素を含む
+      expect(result.current.shuffledItems.sort()).toEqual([...testItems].sort());
+    });
+
+    it('空の配列の場合は空の配列を返す', () => {
+      const { result } = renderHook(() => useShuffle([]));
+
+      expect(result.current.shuffledItems).toEqual([]);
+    });
+
+    it('currentSeedが返される', () => {
+      const { result } = renderHook(() => useShuffle(testItems));
+
+      expect(typeof result.current.currentSeed).toBe('number');
+    });
+  });
+
+  describe('固定シード', () => {
+    it('同じシードで同じ順序になる', () => {
+      const { result: result1 } = renderHook(() =>
+        useShuffle(testItems, { seedType: 'fixed', fixedSeed: 12345 }),
+      );
+
+      const { result: result2 } = renderHook(() =>
+        useShuffle(testItems, { seedType: 'fixed', fixedSeed: 12345 }),
+      );
+
+      expect(result1.current.shuffledItems).toEqual(result2.current.shuffledItems);
+      expect(result1.current.currentSeed).toBe(12345);
+    });
+
+    it('異なるシードで異なる順序になる', () => {
+      const { result: result1 } = renderHook(() =>
+        useShuffle(testItems, { seedType: 'fixed', fixedSeed: 12345 }),
+      );
+
+      const { result: result2 } = renderHook(() =>
+        useShuffle(testItems, { seedType: 'fixed', fixedSeed: 54321 }),
+      );
+
+      // 異なる順序になる可能性が高い
+      const isDifferent =
+        JSON.stringify(result1.current.shuffledItems) !==
+        JSON.stringify(result2.current.shuffledItems);
+      expect(isDifferent).toBe(true);
+    });
+  });
+
+  describe('reshuffle', () => {
+    it('reshuffleで新しいシードで再シャッフルされる', () => {
+      const { result } = renderHook(() =>
+        useShuffle(testItems, { seedType: 'fixed', fixedSeed: 12345 }),
+      );
+
+      const originalSeed = result.current.currentSeed;
+
+      act(() => {
+        result.current.reshuffle();
+      });
+
+      // シードが変わる
+      expect(result.current.currentSeed).not.toBe(originalSeed);
+      // 順序も変わる可能性が高い（まれに同じになる可能性はある）
+      expect(result.current.shuffledItems).toHaveLength(testItems.length);
+    });
+  });
+
+  describe('shuffleWithSeed', () => {
+    it('特定のシードでシャッフルできる', () => {
+      const { result } = renderHook(() => useShuffle(testItems, { seedType: 'random' }));
+
+      act(() => {
+        result.current.shuffleWithSeed(99999);
+      });
+
+      expect(result.current.currentSeed).toBe(99999);
+
+      // 同じシードで別のフックを作成して比較
+      const { result: result2 } = renderHook(() =>
+        useShuffle(testItems, { seedType: 'fixed', fixedSeed: 99999 }),
+      );
+
+      expect(result.current.shuffledItems).toEqual(result2.current.shuffledItems);
+    });
+  });
+
+  describe('シードタイプ', () => {
+    it('hourlyシードがデフォルト', () => {
+      const { result } = renderHook(() => useShuffle(testItems));
+
+      // hourlyシードは時間ベースなので、現在の時間に基づいた値
+      const expectedSeed = Math.floor(Date.now() / (1000 * 60 * 60));
+      expect(result.current.currentSeed).toBe(expectedSeed);
+    });
+
+    it('dailyシードが正しく動作する', () => {
+      const { result } = renderHook(() => useShuffle(testItems, { seedType: 'daily' }));
+
+      const expectedSeed = getDailyShuffleSeed();
+      expect(result.current.currentSeed).toBe(expectedSeed);
+    });
+
+    it('randomシードが毎回異なる', () => {
+      // randomシードは毎回異なる可能性が高い
+      const seed1 = getRandomSeed();
+      const seed2 = getRandomSeed();
+
+      // 同じ値になる確率は極めて低い
+      expect(seed1).not.toBe(seed2);
+    });
+  });
+
+  describe('メモ化', () => {
+    it('同じitemsとseedで同じ配列インスタンスが返される', () => {
+      const { result, rerender } = renderHook(() =>
+        useShuffle(testItems, { seedType: 'fixed', fixedSeed: 12345 }),
+      );
+
+      const firstResult = result.current.shuffledItems;
+
+      rerender();
+
+      expect(result.current.shuffledItems).toBe(firstResult);
+    });
+
+    it('itemsが変わると再シャッフルされる', () => {
+      const { result, rerender } = renderHook(
+        ({ items }) => useShuffle(items, { seedType: 'fixed', fixedSeed: 12345 }),
+        { initialProps: { items: testItems } },
+      );
+
+      const firstResult = [...result.current.shuffledItems];
+
+      rerender({ items: [100, 200, 300] });
+
+      expect(result.current.shuffledItems).not.toEqual(firstResult);
+      expect(result.current.shuffledItems).toHaveLength(3);
+    });
+  });
+});
+
+describe('ヘルパー関数', () => {
+  describe('getDailyShuffleSeed', () => {
+    it('日付ベースのシード値を返す', () => {
+      const seed = getDailyShuffleSeed();
+      const expected = Math.floor(Date.now() / (1000 * 60 * 60 * 24));
+
+      expect(seed).toBe(expected);
+    });
+  });
+
+  describe('getRandomSeed', () => {
+    it('0以上の整数を返す', () => {
+      const seed = getRandomSeed();
+
+      expect(Number.isInteger(seed)).toBe(true);
+      expect(seed).toBeGreaterThanOrEqual(0);
+      expect(seed).toBeLessThan(1000000);
+    });
+  });
+});

--- a/src/hooks/useGameFeedback.ts
+++ b/src/hooks/useGameFeedback.ts
@@ -1,0 +1,176 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useAudio } from '@/contexts/AudioContext';
+
+/**
+ * フィードバックの種類
+ */
+export type FeedbackType = 'correct' | 'incorrect' | 'neutral';
+
+/**
+ * 効果音の種類
+ */
+export type SoundEffect = 'success' | 'error' | 'click' | 'complete';
+
+/**
+ * useGameFeedbackのオプション
+ */
+export interface UseGameFeedbackOptions {
+  /** 正解時の効果音（デフォルト: 'success'） */
+  correctSound?: SoundEffect;
+  /** 不正解時の効果音（デフォルト: 'error'） */
+  incorrectSound?: SoundEffect;
+  /** フィードバック表示時間（ミリ秒、デフォルト: 1500） */
+  feedbackDuration?: number;
+  /** 効果音を有効にするかどうか（デフォルト: true） */
+  soundEnabled?: boolean;
+}
+
+/**
+ * useGameFeedbackの戻り値
+ */
+export interface UseGameFeedbackReturn {
+  /** 現在のフィードバック状態 */
+  feedback: FeedbackType;
+  /** 正解かどうか（null = 未判定） */
+  isCorrect: boolean | null;
+  /** フィードバック表示中かどうか */
+  isShowingFeedback: boolean;
+  /** 正解フィードバックを表示する */
+  showCorrect: () => Promise<void>;
+  /** 不正解フィードバックを表示する */
+  showIncorrect: () => Promise<void>;
+  /** フィードバックをリセットする */
+  resetFeedback: () => void;
+  /** 効果音を再生する */
+  playFeedbackSound: (sound: SoundEffect) => Promise<void>;
+  /** クリック音を再生する */
+  playClick: () => Promise<void>;
+}
+
+/**
+ * ゲームのフィードバック（正解/不正解）を管理するカスタムフック
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   isCorrect,
+ *   isShowingFeedback,
+ *   showCorrect,
+ *   showIncorrect,
+ *   resetFeedback,
+ *   playClick,
+ * } = useGameFeedback({ feedbackDuration: 2000 });
+ *
+ * const handleAnswer = async (answer: string) => {
+ *   if (answer === correctAnswer) {
+ *     await showCorrect();
+ *   } else {
+ *     await showIncorrect();
+ *   }
+ * };
+ *
+ * // フィードバック表示
+ * {isShowingFeedback && (
+ *   <div className={isCorrect ? 'bg-green-500' : 'bg-red-500'}>
+ *     {isCorrect ? '正解！' : '残念...'}
+ *   </div>
+ * )}
+ * ```
+ */
+export function useGameFeedback(options: UseGameFeedbackOptions = {}): UseGameFeedbackReturn {
+  const {
+    correctSound = 'success',
+    incorrectSound = 'error',
+    feedbackDuration = 1500,
+    soundEnabled = true,
+  } = options;
+
+  const [feedback, setFeedback] = useState<FeedbackType>('neutral');
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [isShowingFeedback, setIsShowingFeedback] = useState(false);
+
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { playSound } = useAudio();
+
+  // クリーンアップ
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const playFeedbackSound = useCallback(
+    async (sound: SoundEffect) => {
+      if (soundEnabled) {
+        await playSound(sound);
+      }
+    },
+    [soundEnabled, playSound],
+  );
+
+  const playClick = useCallback(async () => {
+    await playFeedbackSound('click');
+  }, [playFeedbackSound]);
+
+  const showCorrect = useCallback(async () => {
+    // 既存のタイムアウトをクリア
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    setFeedback('correct');
+    setIsCorrect(true);
+    setIsShowingFeedback(true);
+    await playFeedbackSound(correctSound);
+
+    // 指定時間後にフィードバックを終了
+    return new Promise<void>((resolve) => {
+      timeoutRef.current = setTimeout(() => {
+        setIsShowingFeedback(false);
+        resolve();
+      }, feedbackDuration);
+    });
+  }, [correctSound, feedbackDuration, playFeedbackSound]);
+
+  const showIncorrect = useCallback(async () => {
+    // 既存のタイムアウトをクリア
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    setFeedback('incorrect');
+    setIsCorrect(false);
+    setIsShowingFeedback(true);
+    await playFeedbackSound(incorrectSound);
+
+    // 指定時間後にフィードバックを終了
+    return new Promise<void>((resolve) => {
+      timeoutRef.current = setTimeout(() => {
+        setIsShowingFeedback(false);
+        resolve();
+      }, feedbackDuration);
+    });
+  }, [incorrectSound, feedbackDuration, playFeedbackSound]);
+
+  const resetFeedback = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setFeedback('neutral');
+    setIsCorrect(null);
+    setIsShowingFeedback(false);
+  }, []);
+
+  return {
+    feedback,
+    isCorrect,
+    isShowingFeedback,
+    showCorrect,
+    showIncorrect,
+    resetFeedback,
+    playFeedbackSound,
+    playClick,
+  };
+}

--- a/src/hooks/useGameProgress.ts
+++ b/src/hooks/useGameProgress.ts
@@ -1,0 +1,164 @@
+import { useState, useCallback, useMemo } from 'react';
+
+/**
+ * ゲームの進捗状態を管理するためのオプション
+ */
+export interface UseGameProgressOptions {
+  /** アイテムの総数 */
+  totalItems: number;
+  /** 初期インデックス（デフォルト: 0） */
+  initialIndex?: number;
+  /** 初期スコア（デフォルト: 0） */
+  initialScore?: number;
+}
+
+/**
+ * ゲームの進捗状態
+ */
+export interface GameProgressState {
+  /** 現在のインデックス（0始まり） */
+  currentIndex: number;
+  /** 現在のスコア */
+  score: number;
+  /** ゲームが開始されたかどうか */
+  gameStarted: boolean;
+  /** ゲームが完了したかどうか */
+  gameCompleted: boolean;
+}
+
+/**
+ * useGameProgressの戻り値
+ */
+export interface UseGameProgressReturn {
+  /** 現在の状態 */
+  state: GameProgressState;
+  /** 次のアイテムに進む */
+  handleNext: () => void;
+  /** 前のアイテムに戻る */
+  handlePrevious: () => void;
+  /** ゲームをリセットする */
+  resetGame: () => void;
+  /** ゲームを開始する */
+  startGame: () => void;
+  /** スコアを加算する */
+  addScore: (points: number) => void;
+  /** 特定のインデックスに移動する */
+  goToIndex: (index: number) => void;
+  /** 最初のアイテムかどうか */
+  isFirst: boolean;
+  /** 最後のアイテムかどうか */
+  isLast: boolean;
+  /** 進捗率（パーセント） */
+  progress: number;
+  /** アイテムの総数 */
+  totalItems: number;
+}
+
+/**
+ * ゲームの進捗状態を管理するカスタムフック
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   state,
+ *   handleNext,
+ *   handlePrevious,
+ *   progress,
+ *   isFirst,
+ *   isLast,
+ * } = useGameProgress({ totalItems: 10 });
+ *
+ * // 進捗表示
+ * <ProgressBar value={progress} />
+ *
+ * // ナビゲーション
+ * <button onClick={handlePrevious} disabled={isFirst}>前へ</button>
+ * <button onClick={handleNext} disabled={isLast}>次へ</button>
+ * ```
+ */
+export function useGameProgress(options: UseGameProgressOptions): UseGameProgressReturn {
+  const { totalItems, initialIndex = 0, initialScore = 0 } = options;
+
+  const [state, setState] = useState<GameProgressState>({
+    currentIndex: initialIndex,
+    score: initialScore,
+    gameStarted: false,
+    gameCompleted: false,
+  });
+
+  const handleNext = useCallback(() => {
+    setState((prev) => {
+      const nextIndex = prev.currentIndex + 1;
+      const isCompleted = nextIndex >= totalItems;
+      return {
+        ...prev,
+        currentIndex: isCompleted ? prev.currentIndex : nextIndex,
+        gameCompleted: isCompleted,
+      };
+    });
+  }, [totalItems]);
+
+  const handlePrevious = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      currentIndex: Math.max(0, prev.currentIndex - 1),
+    }));
+  }, []);
+
+  const resetGame = useCallback(() => {
+    setState({
+      currentIndex: initialIndex,
+      score: initialScore,
+      gameStarted: false,
+      gameCompleted: false,
+    });
+  }, [initialIndex, initialScore]);
+
+  const startGame = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      gameStarted: true,
+    }));
+  }, []);
+
+  const addScore = useCallback((points: number) => {
+    setState((prev) => ({
+      ...prev,
+      score: prev.score + points,
+    }));
+  }, []);
+
+  const goToIndex = useCallback(
+    (index: number) => {
+      if (index >= 0 && index < totalItems) {
+        setState((prev) => ({
+          ...prev,
+          currentIndex: index,
+          gameCompleted: false,
+        }));
+      }
+    },
+    [totalItems],
+  );
+
+  const isFirst = state.currentIndex === 0;
+  const isLast = state.currentIndex === totalItems - 1;
+  const progress = useMemo(
+    () => (totalItems > 0 ? ((state.currentIndex + 1) / totalItems) * 100 : 0),
+    [state.currentIndex, totalItems],
+  );
+
+  return {
+    state,
+    handleNext,
+    handlePrevious,
+    resetGame,
+    startGame,
+    addScore,
+    goToIndex,
+    isFirst,
+    isLast,
+    progress,
+    totalItems,
+  };
+}

--- a/src/hooks/useGameTimer.ts
+++ b/src/hooks/useGameTimer.ts
@@ -136,7 +136,9 @@ export function useGameTimer(options: UseGameTimerOptions = {}): UseGameTimerRet
   const pause = useCallback(() => {
     if (isRunning) {
       // Calculate elapsed time directly from refs to avoid stale closure
-      pausedTimeRef.current = pausedTimeRef.current + (Date.now() - startTimeRef.current);
+      const currentElapsed = pausedTimeRef.current + (Date.now() - startTimeRef.current);
+      pausedTimeRef.current = currentElapsed;
+      setElapsedTime(currentElapsed); // Update state immediately for UI sync
       setIsRunning(false);
     }
   }, [isRunning]);

--- a/src/hooks/useGameTimer.ts
+++ b/src/hooks/useGameTimer.ts
@@ -1,0 +1,182 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+/**
+ * タイマーの動作モード
+ */
+export type TimerMode = 'countdown' | 'countup';
+
+/**
+ * useGameTimerのオプション
+ */
+export interface UseGameTimerOptions {
+  /** タイムアウト時間（ミリ秒） */
+  timeout?: number;
+  /** タイムアウト時のコールバック */
+  onTimeout?: () => void;
+  /** タイマーモード（デフォルト: 'countdown'） */
+  mode?: TimerMode;
+  /** 自動開始するかどうか（デフォルト: false） */
+  autoStart?: boolean;
+  /** 更新間隔（ミリ秒、デフォルト: 1000） */
+  interval?: number;
+}
+
+/**
+ * useGameTimerの戻り値
+ */
+export interface UseGameTimerReturn {
+  /** 経過時間（ミリ秒） */
+  elapsedTime: number;
+  /** 残り時間（ミリ秒、countdownモードのみ） */
+  remainingTime: number;
+  /** タイマーが動作中かどうか */
+  isRunning: boolean;
+  /** タイムアウトしたかどうか */
+  isTimedOut: boolean;
+  /** タイマーを開始する */
+  start: () => void;
+  /** タイマーを一時停止する */
+  pause: () => void;
+  /** タイマーを再開する */
+  resume: () => void;
+  /** タイマーをリセットする */
+  reset: () => void;
+  /** タイマーを停止してリセットする */
+  stop: () => void;
+}
+
+/**
+ * ゲームのタイマー機能を提供するカスタムフック
+ *
+ * @example
+ * ```tsx
+ * // カウントダウンタイマー（30秒）
+ * const { remainingTime, isTimedOut, start, reset } = useGameTimer({
+ *   timeout: 30000,
+ *   mode: 'countdown',
+ *   onTimeout: () => handleTimeUp(),
+ * });
+ *
+ * // カウントアップタイマー
+ * const { elapsedTime, start, pause, resume } = useGameTimer({
+ *   mode: 'countup',
+ * });
+ * ```
+ */
+export function useGameTimer(options: UseGameTimerOptions = {}): UseGameTimerReturn {
+  const {
+    timeout = 0,
+    onTimeout,
+    mode = 'countdown',
+    autoStart = false,
+    interval = 1000,
+  } = options;
+
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const [isRunning, setIsRunning] = useState(autoStart);
+  const [isTimedOut, setIsTimedOut] = useState(false);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startTimeRef = useRef<number>(autoStart ? Date.now() : 0);
+  const pausedTimeRef = useRef<number>(0);
+  const onTimeoutRef = useRef(onTimeout);
+
+  // onTimeoutのrefを更新
+  useEffect(() => {
+    onTimeoutRef.current = onTimeout;
+  }, [onTimeout]);
+
+  // クリーンアップ
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  // タイマーの実行
+  useEffect(() => {
+    if (isRunning && !isTimedOut) {
+      intervalRef.current = setInterval(() => {
+        const now = Date.now();
+        const newElapsed = pausedTimeRef.current + (now - startTimeRef.current);
+        setElapsedTime(newElapsed);
+
+        // タイムアウトチェック（countdownモードかつtimeoutが設定されている場合）
+        if (mode === 'countdown' && timeout > 0 && newElapsed >= timeout) {
+          setIsTimedOut(true);
+          setIsRunning(false);
+          if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+          }
+          onTimeoutRef.current?.();
+        }
+      }, interval);
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [isRunning, isTimedOut, timeout, mode, interval]);
+
+  const start = useCallback(() => {
+    if (!isRunning && !isTimedOut) {
+      startTimeRef.current = Date.now();
+      pausedTimeRef.current = 0;
+      setElapsedTime(0);
+      setIsRunning(true);
+    }
+  }, [isRunning, isTimedOut]);
+
+  const pause = useCallback(() => {
+    if (isRunning) {
+      // Calculate elapsed time directly from refs to avoid stale closure
+      pausedTimeRef.current = pausedTimeRef.current + (Date.now() - startTimeRef.current);
+      setIsRunning(false);
+    }
+  }, [isRunning]);
+
+  const resume = useCallback(() => {
+    if (!isRunning && !isTimedOut) {
+      startTimeRef.current = Date.now();
+      setIsRunning(true);
+    }
+  }, [isRunning, isTimedOut]);
+
+  const reset = useCallback(() => {
+    setElapsedTime(0);
+    setIsTimedOut(false);
+    pausedTimeRef.current = 0;
+    startTimeRef.current = Date.now();
+  }, []);
+
+  const stop = useCallback(() => {
+    setIsRunning(false);
+    setElapsedTime(0);
+    setIsTimedOut(false);
+    pausedTimeRef.current = 0;
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+  }, []);
+
+  const remainingTime =
+    mode === 'countdown' && timeout > 0 ? Math.max(0, timeout - elapsedTime) : 0;
+
+  return {
+    elapsedTime,
+    remainingTime,
+    isRunning,
+    isTimedOut,
+    start,
+    pause,
+    resume,
+    reset,
+    stop,
+  };
+}

--- a/src/hooks/useKanjiText.ts
+++ b/src/hooks/useKanjiText.ts
@@ -1,0 +1,164 @@
+import { useMemo } from 'react';
+import { useLanguage, type KanjiGrade } from '@/contexts/LanguageContext';
+
+/**
+ * 漢字レベル別のテキストオブジェクト
+ */
+export type KanjiTextMap = { [key in KanjiGrade]: string };
+
+/**
+ * useKanjiTextのオプション
+ */
+export interface UseKanjiTextOptions {
+  /** 漢字レベルを上書きする場合に指定 */
+  overrideGrade?: KanjiGrade;
+  /** フォールバック時に使用するテキスト */
+  fallbackText?: string;
+}
+
+/**
+ * useKanjiTextの戻り値
+ */
+export interface UseKanjiTextReturn {
+  /** 現在の漢字レベルに応じたテキスト */
+  text: string;
+  /** 現在の漢字レベル */
+  currentGrade: KanjiGrade;
+  /** 特定のレベルのテキストを取得する */
+  getTextForGrade: (grade: KanjiGrade) => string;
+}
+
+/**
+ * 漢字レベルに応じたテキストを取得するカスタムフック
+ *
+ * ユーザーの漢字レベル設定に基づいて、適切な漢字レベルのテキストを返す。
+ * 指定されたレベルにテキストがない場合は、より低いレベルにフォールバックする。
+ *
+ * @example
+ * ```tsx
+ * // ストーリーページでの使用
+ * const { text } = useKanjiText(story.jaKanji);
+ *
+ * // 明示的にレベルを指定
+ * const { text } = useKanjiText(sentence.jaKanji, { overrideGrade: 3 });
+ *
+ * // フォールバックテキストを指定
+ * const { text } = useKanjiText(page.jaKanji, {
+ *   fallbackText: page.text.ja,
+ * });
+ * ```
+ */
+export function useKanjiText(
+  kanjiTextMap: KanjiTextMap | undefined,
+  options: UseKanjiTextOptions = {},
+): UseKanjiTextReturn {
+  const { kanjiGrade: contextGrade } = useLanguage();
+  const { overrideGrade, fallbackText = '' } = options;
+
+  const currentGrade = overrideGrade ?? contextGrade;
+
+  const getTextForGrade = useMemo(() => {
+    return (grade: KanjiGrade): string => {
+      if (!kanjiTextMap) {
+        return fallbackText;
+      }
+
+      // 指定されたレベルのテキストがあればそれを返す
+      const text = kanjiTextMap[grade];
+      if (text && text.trim() !== '') {
+        return text;
+      }
+
+      // フォールバック: より低いレベルを探す
+      const grades: KanjiGrade[] = [1, 2, 3, 4, 5, 6];
+      const lowerGrades = grades.filter((g) => g < grade).reverse();
+
+      for (const lowerGrade of lowerGrades) {
+        const lowerText = kanjiTextMap[lowerGrade];
+        if (lowerText && lowerText.trim() !== '') {
+          return lowerText;
+        }
+      }
+
+      // 最低レベルにもない場合はフォールバックテキスト
+      return fallbackText;
+    };
+  }, [kanjiTextMap, fallbackText]);
+
+  const text = useMemo(() => {
+    return getTextForGrade(currentGrade);
+  }, [getTextForGrade, currentGrade]);
+
+  return {
+    text,
+    currentGrade,
+    getTextForGrade,
+  };
+}
+
+/**
+ * 複数のテキストフィールドを一括で漢字レベル変換するヘルパーフック
+ *
+ * @example
+ * ```tsx
+ * const texts = useKanjiTexts({
+ *   title: story.title.jaKanji,
+ *   description: story.description.jaKanji,
+ *   lesson: story.lesson.jaKanji,
+ * });
+ *
+ * return (
+ *   <div>
+ *     <h1>{texts.title}</h1>
+ *     <p>{texts.description}</p>
+ *   </div>
+ * );
+ * ```
+ */
+export function useKanjiTexts(
+  kanjiTextMaps: Record<string, KanjiTextMap | undefined>,
+  options: UseKanjiTextOptions = {},
+): Record<string, string> {
+  const { kanjiGrade: contextGrade } = useLanguage();
+  const { overrideGrade, fallbackText = '' } = options;
+
+  const currentGrade = overrideGrade ?? contextGrade;
+
+  return useMemo(() => {
+    const result: Record<string, string> = {};
+
+    for (const [key, kanjiTextMap] of Object.entries(kanjiTextMaps)) {
+      if (!kanjiTextMap) {
+        result[key] = fallbackText;
+        continue;
+      }
+
+      // 指定されたレベルのテキストがあればそれを返す
+      const text = kanjiTextMap[currentGrade];
+      if (text && text.trim() !== '') {
+        result[key] = text;
+        continue;
+      }
+
+      // フォールバック: より低いレベルを探す
+      const grades: KanjiGrade[] = [1, 2, 3, 4, 5, 6];
+      const lowerGrades = grades.filter((g) => g < currentGrade).reverse();
+
+      let found = false;
+      for (const lowerGrade of lowerGrades) {
+        const lowerText = kanjiTextMap[lowerGrade];
+        if (lowerText && lowerText.trim() !== '') {
+          result[key] = lowerText;
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        result[key] = fallbackText;
+      }
+    }
+
+    return result;
+  }, [kanjiTextMaps, currentGrade, fallbackText]);
+}

--- a/src/hooks/useShuffle.ts
+++ b/src/hooks/useShuffle.ts
@@ -1,0 +1,111 @@
+import { useMemo, useCallback, useState } from 'react';
+import { shuffleArrayWithSeed, getHourlyShuffleSeed } from '@/utils/arrayUtils';
+
+/**
+ * シード生成のタイプ
+ */
+export type SeedType = 'hourly' | 'daily' | 'random' | 'fixed';
+
+/**
+ * useShuffleのオプション
+ */
+export interface UseShuffleOptions {
+  /** シードのタイプ（デフォルト: 'hourly'） */
+  seedType?: SeedType;
+  /** 固定シード値（seedType='fixed'の場合に使用） */
+  fixedSeed?: number;
+}
+
+/**
+ * useShuffleの戻り値
+ */
+export interface UseShuffleReturn<T> {
+  /** シャッフルされた配列 */
+  shuffledItems: T[];
+  /** 現在のシード値 */
+  currentSeed: number;
+  /** 新しいシードで再シャッフルする */
+  reshuffle: () => void;
+  /** 特定のシードでシャッフルする */
+  shuffleWithSeed: (seed: number) => void;
+}
+
+/**
+ * 日付ベースのシード値を生成する（1日ごとに変化）
+ */
+export function getDailyShuffleSeed(): number {
+  return Math.floor(Date.now() / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * ランダムなシード値を生成する
+ */
+export function getRandomSeed(): number {
+  return Math.floor(Math.random() * 1000000);
+}
+
+/**
+ * シードタイプに基づいてシード値を取得する
+ */
+function getSeedByType(seedType: SeedType, fixedSeed?: number): number {
+  switch (seedType) {
+    case 'hourly':
+      return getHourlyShuffleSeed();
+    case 'daily':
+      return getDailyShuffleSeed();
+    case 'random':
+      return getRandomSeed();
+    case 'fixed':
+      return fixedSeed ?? 0;
+    default:
+      return getHourlyShuffleSeed();
+  }
+}
+
+/**
+ * 配列をシャッフルするカスタムフック
+ *
+ * @example
+ * ```tsx
+ * // 1時間ごとに同じ順序になるシャッフル
+ * const { shuffledItems } = useShuffle(vocabularyWords, { seedType: 'hourly' });
+ *
+ * // 固定シードでのシャッフル（テスト用）
+ * const { shuffledItems } = useShuffle(items, {
+ *   seedType: 'fixed',
+ *   fixedSeed: 12345,
+ * });
+ *
+ * // 手動で再シャッフル
+ * const { shuffledItems, reshuffle } = useShuffle(items);
+ * <button onClick={reshuffle}>シャッフル</button>
+ * ```
+ */
+export function useShuffle<T>(items: T[], options: UseShuffleOptions = {}): UseShuffleReturn<T> {
+  const { seedType = 'hourly', fixedSeed } = options;
+
+  const [seed, setSeed] = useState(() => getSeedByType(seedType, fixedSeed));
+
+  const shuffledItems = useMemo(() => {
+    if (items.length === 0) {
+      return [];
+    }
+    return shuffleArrayWithSeed(items, seed);
+  }, [items, seed]);
+
+  const reshuffle = useCallback(() => {
+    // reshuffleは常にランダムなシードを使用
+    setSeed(getRandomSeed());
+  }, []);
+
+  const shuffleWithSeed = useCallback((newSeed: number) => {
+    setSeed(newSeed);
+  }, []);
+
+  return {
+    shuffledItems,
+    currentSeed: seed,
+    reshuffle,
+    shuffleWithSeed,
+  };
+}


### PR DESCRIPTION
## Summary

Issue #4 の実装：ゲームページ（VocabularyGamePage, SpellingGamePage, StoryPage）で重複しているロジックを再利用可能なカスタムフックに抽出しました。

### 作成したカスタムフック

| Hook | 機能 |
|------|------|
| `useGameProgress` | 進捗追跡、スコア管理、ゲーム状態管理 |
| `useGameTimer` | タイマー/タイムアウト機能（カウントダウン/カウントアップ対応） |
| `useShuffle` | シャッフル機能のラッパー（時間・日付・ランダム・固定シード対応） |
| `useGameFeedback` | 正解/不正解状態と効果音の管理 |
| `useKanjiText` | 漢字レベルに基づくテキスト取得（フォールバック対応） |

### 変更内容

- 5つの新しいカスタムフック作成（`src/hooks/`）
- 各フックに対応するユニットテスト（`src/hooks/__tests__/`）
- 全フック80%以上のテストカバレッジ達成

## Test Plan

- [x] `npm run lint` - ESLint通過
- [x] `npm run typecheck` - TypeScript型チェック通過
- [x] `npm run test:unit` - 227テスト全て通過
- [x] Pre-commit hooks通過

## Notes

- ゲームページへのフック適用は別Issueで実施予定（段階的移行）
- 既存のゲームページには影響なし（後方互換性維持）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)